### PR TITLE
Unix support

### DIFF
--- a/FFmpeg.m
+++ b/FFmpeg.m
@@ -93,7 +93,8 @@ FFmpeg[] :=
 Switch[ $OperatingSystem, 
   "MacOSX",  FFmpeg @ "/usr/local/bin/ffmpeg", (*homebrew*)
   "Windows", FFmpeg @ "ffmpeg.exe",
-  "Linux",   FFmpeg @ "ffmpeg" ];
+  "Linux",   FFmpeg @ "ffmpeg",
+  "Unix",   FFmpeg @ "ffmpeg" ];
 
 
 (* ::Subsection::Closed:: *)
@@ -219,7 +220,8 @@ FFprobe[] :=
 Switch[ $OperatingSystem, 
   "MacOSX",  FFprobe @ "/usr/local/bin/ffprobe",
   "Windows", FFprobe @ "ffprobe.exe",
-  "Linux",   FFprobe @ "ffprobe"];
+  "Linux",   FFprobe @ "ffprobe",
+  "Unix",    FFprobe @ "ffprobe"];
 
 
 FFProbe[file_String, streamCodec_String, targetVariable_String] := 


### PR DESCRIPTION
Although I use GNU/Linux, which is [per definition not Unix](https://www.gnu.org/gnu/about-gnu.html), Mathematica somehow thinks that I'm on Unix as `$OperatingSystem == "Unix"`. With this little modification this package works perfectly under GNU/Linux.